### PR TITLE
休講・補講・教室変更の一覧取得ハンドラを実装

### DIFF
--- a/internal/domain/cancelled_class.go
+++ b/internal/domain/cancelled_class.go
@@ -13,7 +13,7 @@ type CancelledClass struct {
 
 // CancelledClassQuery 休講検索クエリ
 type CancelledClassQuery struct {
-	SubjectIds *[]string
+	SubjectIDs *[]string
 	From       *time.Time
 	Until      *time.Time
 }

--- a/internal/domain/cancelled_class.go
+++ b/internal/domain/cancelled_class.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// CancelledClass 休講
+type CancelledClass struct {
+	ID      string
+	Comment string
+	Date    time.Time
+	Period  Period
+	Subject Subject
+}
+
+// CancelledClassQuery 休講検索クエリ
+type CancelledClassQuery struct {
+	SubjectIds *[]string
+	From       *time.Time
+	Until      *time.Time
+}

--- a/internal/domain/makeup_class.go
+++ b/internal/domain/makeup_class.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// MakeupClass 補講
+type MakeupClass struct {
+	ID      string
+	Comment string
+	Date    time.Time
+	Period  Period
+	Subject Subject
+}
+
+// MakeupClassQuery 補講検索クエリ
+type MakeupClassQuery struct {
+	SubjectIds *[]string
+	From       *time.Time
+	Until      *time.Time
+}

--- a/internal/domain/makeup_class.go
+++ b/internal/domain/makeup_class.go
@@ -13,7 +13,7 @@ type MakeupClass struct {
 
 // MakeupClassQuery 補講検索クエリ
 type MakeupClassQuery struct {
-	SubjectIds *[]string
+	SubjectIDs *[]string
 	From       *time.Time
 	Until      *time.Time
 }

--- a/internal/domain/room_change.go
+++ b/internal/domain/room_change.go
@@ -14,7 +14,7 @@ type RoomChange struct {
 
 // RoomChangeQuery 教室変更検索クエリ
 type RoomChangeQuery struct {
-	SubjectIds *[]string
+	SubjectIDs *[]string
 	From       *time.Time
 	Until      *time.Time
 }

--- a/internal/domain/room_change.go
+++ b/internal/domain/room_change.go
@@ -1,0 +1,20 @@
+package domain
+
+import "time"
+
+// RoomChange 教室変更
+type RoomChange struct {
+	ID           string
+	Date         time.Time
+	Period       Period
+	Subject      Subject
+	OriginalRoom Room
+	NewRoom      Room
+}
+
+// RoomChangeQuery 教室変更検索クエリ
+type RoomChangeQuery struct {
+	SubjectIds *[]string
+	From       *time.Time
+	Until      *time.Time
+}

--- a/internal/external/cancelled_class_model.go
+++ b/internal/external/cancelled_class_model.go
@@ -1,0 +1,34 @@
+package external
+
+import (
+	"github.com/fun-dotto/app-bff-api/generated/external/academic_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ToDomainCancelledClass は外部APIのCancelledClassをDomainに変換する
+func ToDomainCancelledClass(m academic_api.CancelledClass) domain.CancelledClass {
+	return domain.CancelledClass{
+		ID:      m.Id,
+		Comment: m.Comment,
+		Date:    m.Date.Time,
+		Period:  domain.Period(m.Period),
+		Subject: ToDomainSubjectSummary(m.Subject),
+	}
+}
+
+// ToExternalCancelledClassQuery はDomainのCancelledClassQueryを外部APIのパラメータに変換する
+func ToExternalCancelledClassQuery(q domain.CancelledClassQuery) *academic_api.CancelledClassesV1ListParams {
+	params := &academic_api.CancelledClassesV1ListParams{
+		SubjectIds: q.SubjectIds,
+	}
+	if q.From != nil {
+		d := openapi_types.Date{Time: *q.From}
+		params.From = &d
+	}
+	if q.Until != nil {
+		d := openapi_types.Date{Time: *q.Until}
+		params.Until = &d
+	}
+	return params
+}

--- a/internal/external/cancelled_class_model.go
+++ b/internal/external/cancelled_class_model.go
@@ -20,7 +20,7 @@ func ToDomainCancelledClass(m academic_api.CancelledClass) domain.CancelledClass
 // ToExternalCancelledClassQuery はDomainのCancelledClassQueryを外部APIのパラメータに変換する
 func ToExternalCancelledClassQuery(q domain.CancelledClassQuery) *academic_api.CancelledClassesV1ListParams {
 	params := &academic_api.CancelledClassesV1ListParams{
-		SubjectIds: q.SubjectIds,
+		SubjectIds: q.SubjectIDs,
 	}
 	if q.From != nil {
 		d := openapi_types.Date{Time: *q.From}

--- a/internal/external/makeup_class_model.go
+++ b/internal/external/makeup_class_model.go
@@ -20,7 +20,7 @@ func ToDomainMakeupClass(m academic_api.MakeupClass) domain.MakeupClass {
 // ToExternalMakeupClassQuery はDomainのMakeupClassQueryを外部APIのパラメータに変換する
 func ToExternalMakeupClassQuery(q domain.MakeupClassQuery) *academic_api.MakeupClassesV1ListParams {
 	params := &academic_api.MakeupClassesV1ListParams{
-		SubjectIds: q.SubjectIds,
+		SubjectIds: q.SubjectIDs,
 	}
 	if q.From != nil {
 		d := openapi_types.Date{Time: *q.From}

--- a/internal/external/makeup_class_model.go
+++ b/internal/external/makeup_class_model.go
@@ -1,0 +1,34 @@
+package external
+
+import (
+	"github.com/fun-dotto/app-bff-api/generated/external/academic_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ToDomainMakeupClass は外部APIのMakeupClassをDomainに変換する
+func ToDomainMakeupClass(m academic_api.MakeupClass) domain.MakeupClass {
+	return domain.MakeupClass{
+		ID:      m.Id,
+		Comment: m.Comment,
+		Date:    m.Date.Time,
+		Period:  domain.Period(m.Period),
+		Subject: ToDomainSubjectSummary(m.Subject),
+	}
+}
+
+// ToExternalMakeupClassQuery はDomainのMakeupClassQueryを外部APIのパラメータに変換する
+func ToExternalMakeupClassQuery(q domain.MakeupClassQuery) *academic_api.MakeupClassesV1ListParams {
+	params := &academic_api.MakeupClassesV1ListParams{
+		SubjectIds: q.SubjectIds,
+	}
+	if q.From != nil {
+		d := openapi_types.Date{Time: *q.From}
+		params.From = &d
+	}
+	if q.Until != nil {
+		d := openapi_types.Date{Time: *q.Until}
+		params.Until = &d
+	}
+	return params
+}

--- a/internal/external/room_change_model.go
+++ b/internal/external/room_change_model.go
@@ -29,7 +29,7 @@ func ToDomainRoomChange(m academic_api.RoomChange) domain.RoomChange {
 // ToExternalRoomChangeQuery はDomainのRoomChangeQueryを外部APIのパラメータに変換する
 func ToExternalRoomChangeQuery(q domain.RoomChangeQuery) *academic_api.RoomChangesV1ListParams {
 	params := &academic_api.RoomChangesV1ListParams{
-		SubjectIds: q.SubjectIds,
+		SubjectIds: q.SubjectIDs,
 	}
 	if q.From != nil {
 		d := openapi_types.Date{Time: *q.From}

--- a/internal/external/room_change_model.go
+++ b/internal/external/room_change_model.go
@@ -1,0 +1,43 @@
+package external
+
+import (
+	"github.com/fun-dotto/app-bff-api/generated/external/academic_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ToDomainRoomChange は外部APIのRoomChangeをDomainに変換する
+func ToDomainRoomChange(m academic_api.RoomChange) domain.RoomChange {
+	return domain.RoomChange{
+		ID:     m.Id,
+		Date:   m.Date.Time,
+		Period: domain.Period(m.Period),
+		Subject: ToDomainSubjectSummary(m.Subject),
+		OriginalRoom: domain.Room{
+			ID:    m.OriginalRoom.Id,
+			Name:  m.OriginalRoom.Name,
+			Floor: domain.Floor(m.OriginalRoom.Floor),
+		},
+		NewRoom: domain.Room{
+			ID:    m.NewRoom.Id,
+			Name:  m.NewRoom.Name,
+			Floor: domain.Floor(m.NewRoom.Floor),
+		},
+	}
+}
+
+// ToExternalRoomChangeQuery はDomainのRoomChangeQueryを外部APIのパラメータに変換する
+func ToExternalRoomChangeQuery(q domain.RoomChangeQuery) *academic_api.RoomChangesV1ListParams {
+	params := &academic_api.RoomChangesV1ListParams{
+		SubjectIds: q.SubjectIds,
+	}
+	if q.From != nil {
+		d := openapi_types.Date{Time: *q.From}
+		params.From = &d
+	}
+	if q.Until != nil {
+		d := openapi_types.Date{Time: *q.Until}
+		params.Until = &d
+	}
+	return params
+}

--- a/internal/handler/cancelled_class.go
+++ b/internal/handler/cancelled_class.go
@@ -33,7 +33,7 @@ func (h *Handler) CancelledClassesV1List(ctx context.Context, request api.Cancel
 
 func toCancelledClassQuery(params api.CancelledClassesV1ListParams) domain.CancelledClassQuery {
 	query := domain.CancelledClassQuery{
-		SubjectIds: params.SubjectIds,
+		SubjectIDs: params.SubjectIds,
 	}
 	if params.From != nil {
 		t := params.From.Time

--- a/internal/handler/cancelled_class.go
+++ b/internal/handler/cancelled_class.go
@@ -5,8 +5,53 @@ import (
 	"fmt"
 
 	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func (h *Handler) CancelledClassesV1List(_ context.Context, _ api.CancelledClassesV1ListRequestObject) (api.CancelledClassesV1ListResponseObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *Handler) CancelledClassesV1List(ctx context.Context, request api.CancelledClassesV1ListRequestObject) (api.CancelledClassesV1ListResponseObject, error) {
+	if h.academicService == nil {
+		return nil, errAcademicServiceNotConfigured
+	}
+
+	query := toCancelledClassQuery(request.Params)
+
+	classes, err := h.academicService.GetCancelledClasses(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cancelled classes: %w", err)
+	}
+
+	apiClasses := make([]api.CancelledClass, len(classes))
+	for i, c := range classes {
+		apiClasses[i] = toApiCancelledClass(c)
+	}
+
+	return api.CancelledClassesV1List200JSONResponse{
+		CancelledClasses: apiClasses,
+	}, nil
+}
+
+func toCancelledClassQuery(params api.CancelledClassesV1ListParams) domain.CancelledClassQuery {
+	query := domain.CancelledClassQuery{
+		SubjectIds: params.SubjectIds,
+	}
+	if params.From != nil {
+		t := params.From.Time
+		query.From = &t
+	}
+	if params.Until != nil {
+		t := params.Until.Time
+		query.Until = &t
+	}
+	return query
+}
+
+func toApiCancelledClass(c domain.CancelledClass) api.CancelledClass {
+	return api.CancelledClass{
+		Id:      c.ID,
+		Comment: c.Comment,
+		Date:    openapi_types.Date{Time: c.Date},
+		Period:  api.DottoFoundationV1Period(c.Period),
+		Subject: toApiSubjectSummary(c.Subject),
+	}
 }

--- a/internal/handler/cancelled_class_test.go
+++ b/internal/handler/cancelled_class_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/repository"
+	"github.com/fun-dotto/app-bff-api/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelledClassesV1List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  *Handler
+		validate func(t *testing.T, resp api.CancelledClassesV1ListResponseObject, err error)
+	}{
+		{
+			name:    "正常に休講一覧が取得できる",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepository()))),
+			validate: func(t *testing.T, resp api.CancelledClassesV1ListResponseObject, err error) {
+				require.NoError(t, err)
+				result, ok := resp.(api.CancelledClassesV1List200JSONResponse)
+				require.True(t, ok, "レスポンスが200 JSONレスポンスではありません")
+				require.Len(t, result.CancelledClasses, 1)
+				assert.Equal(t, "cancelled-1", result.CancelledClasses[0].Id)
+				assert.Equal(t, "教員出張のため", result.CancelledClasses[0].Comment)
+				assert.Equal(t, api.DottoFoundationV1Period("Period1"), result.CancelledClasses[0].Period)
+				assert.Equal(t, "s1", result.CancelledClasses[0].Subject.Id)
+			},
+		},
+		{
+			name:    "academicServiceが未設定の場合エラーを返す",
+			handler: NewHandler(),
+			validate: func(t *testing.T, resp api.CancelledClassesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errAcademicServiceNotConfigured)
+			},
+		},
+		{
+			name:    "serviceがエラーを返す場合エラーを返す",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepositoryWithError("getCancelledClasses", fmt.Errorf("db error"))))),
+			validate: func(t *testing.T, resp api.CancelledClassesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get cancelled classes")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.handler.CancelledClassesV1List(context.Background(), api.CancelledClassesV1ListRequestObject{})
+			tt.validate(t, resp, err)
+		})
+	}
+}

--- a/internal/handler/makeup_class.go
+++ b/internal/handler/makeup_class.go
@@ -33,7 +33,7 @@ func (h *Handler) MakeupClassesV1List(ctx context.Context, request api.MakeupCla
 
 func toMakeupClassQuery(params api.MakeupClassesV1ListParams) domain.MakeupClassQuery {
 	query := domain.MakeupClassQuery{
-		SubjectIds: params.SubjectIds,
+		SubjectIDs: params.SubjectIds,
 	}
 	if params.From != nil {
 		t := params.From.Time

--- a/internal/handler/makeup_class.go
+++ b/internal/handler/makeup_class.go
@@ -5,8 +5,53 @@ import (
 	"fmt"
 
 	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func (h *Handler) MakeupClassesV1List(_ context.Context, _ api.MakeupClassesV1ListRequestObject) (api.MakeupClassesV1ListResponseObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *Handler) MakeupClassesV1List(ctx context.Context, request api.MakeupClassesV1ListRequestObject) (api.MakeupClassesV1ListResponseObject, error) {
+	if h.academicService == nil {
+		return nil, errAcademicServiceNotConfigured
+	}
+
+	query := toMakeupClassQuery(request.Params)
+
+	classes, err := h.academicService.GetMakeupClasses(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get makeup classes: %w", err)
+	}
+
+	apiClasses := make([]api.MakeupClass, len(classes))
+	for i, c := range classes {
+		apiClasses[i] = toApiMakeupClass(c)
+	}
+
+	return api.MakeupClassesV1List200JSONResponse{
+		MakeupClasses: apiClasses,
+	}, nil
+}
+
+func toMakeupClassQuery(params api.MakeupClassesV1ListParams) domain.MakeupClassQuery {
+	query := domain.MakeupClassQuery{
+		SubjectIds: params.SubjectIds,
+	}
+	if params.From != nil {
+		t := params.From.Time
+		query.From = &t
+	}
+	if params.Until != nil {
+		t := params.Until.Time
+		query.Until = &t
+	}
+	return query
+}
+
+func toApiMakeupClass(c domain.MakeupClass) api.MakeupClass {
+	return api.MakeupClass{
+		Id:      c.ID,
+		Comment: c.Comment,
+		Date:    openapi_types.Date{Time: c.Date},
+		Period:  api.DottoFoundationV1Period(c.Period),
+		Subject: toApiSubjectSummary(c.Subject),
+	}
 }

--- a/internal/handler/makeup_class_test.go
+++ b/internal/handler/makeup_class_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/repository"
+	"github.com/fun-dotto/app-bff-api/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeupClassesV1List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  *Handler
+		validate func(t *testing.T, resp api.MakeupClassesV1ListResponseObject, err error)
+	}{
+		{
+			name:    "正常に補講一覧が取得できる",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepository()))),
+			validate: func(t *testing.T, resp api.MakeupClassesV1ListResponseObject, err error) {
+				require.NoError(t, err)
+				result, ok := resp.(api.MakeupClassesV1List200JSONResponse)
+				require.True(t, ok, "レスポンスが200 JSONレスポンスではありません")
+				require.Len(t, result.MakeupClasses, 1)
+				assert.Equal(t, "makeup-1", result.MakeupClasses[0].Id)
+				assert.Equal(t, "休講分の補講", result.MakeupClasses[0].Comment)
+				assert.Equal(t, api.DottoFoundationV1Period("Period2"), result.MakeupClasses[0].Period)
+				assert.Equal(t, "s1", result.MakeupClasses[0].Subject.Id)
+			},
+		},
+		{
+			name:    "academicServiceが未設定の場合エラーを返す",
+			handler: NewHandler(),
+			validate: func(t *testing.T, resp api.MakeupClassesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errAcademicServiceNotConfigured)
+			},
+		},
+		{
+			name:    "serviceがエラーを返す場合エラーを返す",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepositoryWithError("getMakeupClasses", fmt.Errorf("db error"))))),
+			validate: func(t *testing.T, resp api.MakeupClassesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get makeup classes")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.handler.MakeupClassesV1List(context.Background(), api.MakeupClassesV1ListRequestObject{})
+			tt.validate(t, resp, err)
+		})
+	}
+}

--- a/internal/handler/room_change.go
+++ b/internal/handler/room_change.go
@@ -33,7 +33,7 @@ func (h *Handler) RoomChangesV1List(ctx context.Context, request api.RoomChanges
 
 func toRoomChangeQuery(params api.RoomChangesV1ListParams) domain.RoomChangeQuery {
 	query := domain.RoomChangeQuery{
-		SubjectIds: params.SubjectIds,
+		SubjectIDs: params.SubjectIds,
 	}
 	if params.From != nil {
 		t := params.From.Time

--- a/internal/handler/room_change.go
+++ b/internal/handler/room_change.go
@@ -5,8 +5,62 @@ import (
 	"fmt"
 
 	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func (h *Handler) RoomChangesV1List(_ context.Context, _ api.RoomChangesV1ListRequestObject) (api.RoomChangesV1ListResponseObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *Handler) RoomChangesV1List(ctx context.Context, request api.RoomChangesV1ListRequestObject) (api.RoomChangesV1ListResponseObject, error) {
+	if h.academicService == nil {
+		return nil, errAcademicServiceNotConfigured
+	}
+
+	query := toRoomChangeQuery(request.Params)
+
+	changes, err := h.academicService.GetRoomChanges(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get room changes: %w", err)
+	}
+
+	apiChanges := make([]api.RoomChange, len(changes))
+	for i, c := range changes {
+		apiChanges[i] = toApiRoomChange(c)
+	}
+
+	return api.RoomChangesV1List200JSONResponse{
+		RoomChanges: apiChanges,
+	}, nil
+}
+
+func toRoomChangeQuery(params api.RoomChangesV1ListParams) domain.RoomChangeQuery {
+	query := domain.RoomChangeQuery{
+		SubjectIds: params.SubjectIds,
+	}
+	if params.From != nil {
+		t := params.From.Time
+		query.From = &t
+	}
+	if params.Until != nil {
+		t := params.Until.Time
+		query.Until = &t
+	}
+	return query
+}
+
+func toApiRoomChange(c domain.RoomChange) api.RoomChange {
+	return api.RoomChange{
+		Id:   c.ID,
+		Date: openapi_types.Date{Time: c.Date},
+		Period:  api.DottoFoundationV1Period(c.Period),
+		Subject: toApiSubjectSummary(c.Subject),
+		OriginalRoom: api.Room{
+			Id:    c.OriginalRoom.ID,
+			Name:  c.OriginalRoom.Name,
+			Floor: api.DottoFoundationV1Floor(c.OriginalRoom.Floor),
+		},
+		NewRoom: api.Room{
+			Id:    c.NewRoom.ID,
+			Name:  c.NewRoom.Name,
+			Floor: api.DottoFoundationV1Floor(c.NewRoom.Floor),
+		},
+	}
 }

--- a/internal/handler/room_change_test.go
+++ b/internal/handler/room_change_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/repository"
+	"github.com/fun-dotto/app-bff-api/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoomChangesV1List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  *Handler
+		validate func(t *testing.T, resp api.RoomChangesV1ListResponseObject, err error)
+	}{
+		{
+			name:    "正常に教室変更一覧が取得できる",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepository()))),
+			validate: func(t *testing.T, resp api.RoomChangesV1ListResponseObject, err error) {
+				require.NoError(t, err)
+				result, ok := resp.(api.RoomChangesV1List200JSONResponse)
+				require.True(t, ok, "レスポンスが200 JSONレスポンスではありません")
+				require.Len(t, result.RoomChanges, 1)
+				assert.Equal(t, "room-change-1", result.RoomChanges[0].Id)
+				assert.Equal(t, api.DottoFoundationV1Period("Period3"), result.RoomChanges[0].Period)
+				assert.Equal(t, "s1", result.RoomChanges[0].Subject.Id)
+				assert.Equal(t, "r1", result.RoomChanges[0].OriginalRoom.Id)
+				assert.Equal(t, "101講義室", result.RoomChanges[0].OriginalRoom.Name)
+				assert.Equal(t, api.DottoFoundationV1Floor("Floor1"), result.RoomChanges[0].OriginalRoom.Floor)
+				assert.Equal(t, "r2", result.RoomChanges[0].NewRoom.Id)
+				assert.Equal(t, "201講義室", result.RoomChanges[0].NewRoom.Name)
+				assert.Equal(t, api.DottoFoundationV1Floor("Floor2"), result.RoomChanges[0].NewRoom.Floor)
+			},
+		},
+		{
+			name:    "academicServiceが未設定の場合エラーを返す",
+			handler: NewHandler(),
+			validate: func(t *testing.T, resp api.RoomChangesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errAcademicServiceNotConfigured)
+			},
+		},
+		{
+			name:    "serviceがエラーを返す場合エラーを返す",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepositoryWithError("getRoomChanges", fmt.Errorf("db error"))))),
+			validate: func(t *testing.T, resp api.RoomChangesV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get room changes")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.handler.RoomChangesV1List(context.Background(), api.RoomChangesV1ListRequestObject{})
+			tt.validate(t, resp, err)
+		})
+	}
+}

--- a/internal/repository/academic.go
+++ b/internal/repository/academic.go
@@ -203,6 +203,72 @@ func (r *AcademicRepository) GetSubject(id string) (*domain.Subject, error) {
 	return &s, nil
 }
 
+// GetCancelledClasses は外部APIから休講一覧を取得する
+func (r *AcademicRepository) GetCancelledClasses(query domain.CancelledClassQuery) ([]domain.CancelledClass, error) {
+	params := external.ToExternalCancelledClassQuery(query)
+
+	response, err := r.client.CancelledClassesV1ListWithResponse(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call academic API: %w", err)
+	}
+
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get cancelled classes: status %d", response.StatusCode())
+	}
+
+	items := response.JSON200.CancelledClasses
+	result := make([]domain.CancelledClass, len(items))
+	for i, item := range items {
+		result[i] = external.ToDomainCancelledClass(item)
+	}
+
+	return result, nil
+}
+
+// GetMakeupClasses は外部APIから補講一覧を取得する
+func (r *AcademicRepository) GetMakeupClasses(query domain.MakeupClassQuery) ([]domain.MakeupClass, error) {
+	params := external.ToExternalMakeupClassQuery(query)
+
+	response, err := r.client.MakeupClassesV1ListWithResponse(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call academic API: %w", err)
+	}
+
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get makeup classes: status %d", response.StatusCode())
+	}
+
+	items := response.JSON200.MakeupClasses
+	result := make([]domain.MakeupClass, len(items))
+	for i, item := range items {
+		result[i] = external.ToDomainMakeupClass(item)
+	}
+
+	return result, nil
+}
+
+// GetRoomChanges は外部APIから教室変更一覧を取得する
+func (r *AcademicRepository) GetRoomChanges(query domain.RoomChangeQuery) ([]domain.RoomChange, error) {
+	params := external.ToExternalRoomChangeQuery(query)
+
+	response, err := r.client.RoomChangesV1ListWithResponse(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call academic API: %w", err)
+	}
+
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get room changes: status %d", response.StatusCode())
+	}
+
+	items := response.JSON200.RoomChanges
+	result := make([]domain.RoomChange, len(items))
+	for i, item := range items {
+		result[i] = external.ToDomainRoomChange(item)
+	}
+
+	return result, nil
+}
+
 func externalToCourseSemesters(semesters []domain.CourseSemester) []academic_api.DottoFoundationV1CourseSemester {
 	result := make([]academic_api.DottoFoundationV1CourseSemester, len(semesters))
 	for i, semester := range semesters {

--- a/internal/repository/academic_mock.go
+++ b/internal/repository/academic_mock.go
@@ -167,3 +167,15 @@ func (m *MockAcademicRepository) GetPersonalCalendarItems(_ string, _ []time.Tim
 	}
 	return m.personalCalendarItems, nil
 }
+
+func (m *MockAcademicRepository) GetCancelledClasses(_ domain.CancelledClassQuery) ([]domain.CancelledClass, error) {
+	return []domain.CancelledClass{}, nil
+}
+
+func (m *MockAcademicRepository) GetMakeupClasses(_ domain.MakeupClassQuery) ([]domain.MakeupClass, error) {
+	return []domain.MakeupClass{}, nil
+}
+
+func (m *MockAcademicRepository) GetRoomChanges(_ domain.RoomChangeQuery) ([]domain.RoomChange, error) {
+	return []domain.RoomChange{}, nil
+}

--- a/internal/repository/academic_mock.go
+++ b/internal/repository/academic_mock.go
@@ -19,6 +19,9 @@ type MockAcademicRepository struct {
 	getSubjectError             error
 	getRegistrationsErr         error
 	getPersonalCalendarItemsErr error
+	getCancelledClassesErr      error
+	getMakeupClassesErr         error
+	getRoomChangesErr           error
 }
 
 func NewMockAcademicRepository() *MockAcademicRepository {
@@ -89,6 +92,12 @@ func NewMockAcademicRepositoryWithError(field string, err error) *MockAcademicRe
 		m.getRegistrationsErr = err
 	case "getPersonalCalendarItems":
 		m.getPersonalCalendarItemsErr = err
+	case "getCancelledClasses":
+		m.getCancelledClassesErr = err
+	case "getMakeupClasses":
+		m.getMakeupClassesErr = err
+	case "getRoomChanges":
+		m.getRoomChangesErr = err
 	}
 	return m
 }
@@ -169,13 +178,55 @@ func (m *MockAcademicRepository) GetPersonalCalendarItems(_ string, _ []time.Tim
 }
 
 func (m *MockAcademicRepository) GetCancelledClasses(_ domain.CancelledClassQuery) ([]domain.CancelledClass, error) {
-	return []domain.CancelledClass{}, nil
+	if m.getCancelledClassesErr != nil {
+		return nil, m.getCancelledClassesErr
+	}
+	return []domain.CancelledClass{
+		{
+			ID:      "cancelled-1",
+			Comment: "教員出張のため",
+			Date:    time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+			Period:  domain.PeriodPeriod1,
+			Subject: m.subjects[0],
+		},
+	}, nil
 }
 
 func (m *MockAcademicRepository) GetMakeupClasses(_ domain.MakeupClassQuery) ([]domain.MakeupClass, error) {
-	return []domain.MakeupClass{}, nil
+	if m.getMakeupClassesErr != nil {
+		return nil, m.getMakeupClassesErr
+	}
+	return []domain.MakeupClass{
+		{
+			ID:      "makeup-1",
+			Comment: "休講分の補講",
+			Date:    time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+			Period:  domain.PeriodPeriod2,
+			Subject: m.subjects[0],
+		},
+	}, nil
 }
 
 func (m *MockAcademicRepository) GetRoomChanges(_ domain.RoomChangeQuery) ([]domain.RoomChange, error) {
-	return []domain.RoomChange{}, nil
+	if m.getRoomChangesErr != nil {
+		return nil, m.getRoomChangesErr
+	}
+	return []domain.RoomChange{
+		{
+			ID:      "room-change-1",
+			Date:    time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+			Period:  domain.PeriodPeriod3,
+			Subject: m.subjects[0],
+			OriginalRoom: domain.Room{
+				ID:    "r1",
+				Name:  "101講義室",
+				Floor: domain.Floor1,
+			},
+			NewRoom: domain.Room{
+				ID:    "r2",
+				Name:  "201講義室",
+				Floor: domain.Floor2,
+			},
+		},
+	}, nil
 }

--- a/internal/service/academic.go
+++ b/internal/service/academic.go
@@ -16,6 +16,9 @@ type AcademicRepository interface {
 	DeleteCourseRegistration(id string) error
 	GetTimetableItems(query domain.TimetableItemQuery) ([]domain.TimetableItem, error)
 	GetPersonalCalendarItems(userID string, dates []time.Time) ([]domain.PersonalCalendarItem, error)
+	GetCancelledClasses(query domain.CancelledClassQuery) ([]domain.CancelledClass, error)
+	GetMakeupClasses(query domain.MakeupClassQuery) ([]domain.MakeupClass, error)
+	GetRoomChanges(query domain.RoomChangeQuery) ([]domain.RoomChange, error)
 }
 
 type AcademicService struct {
@@ -60,5 +63,17 @@ func (s *AcademicService) GetTimetableItems(query domain.TimetableItemQuery) ([]
 
 func (s *AcademicService) GetPersonalCalendarItems(userID string, dates []time.Time) ([]domain.PersonalCalendarItem, error) {
 	return s.repository.GetPersonalCalendarItems(userID, dates)
+}
+
+func (s *AcademicService) GetCancelledClasses(query domain.CancelledClassQuery) ([]domain.CancelledClass, error) {
+	return s.repository.GetCancelledClasses(query)
+}
+
+func (s *AcademicService) GetMakeupClasses(query domain.MakeupClassQuery) ([]domain.MakeupClass, error) {
+	return s.repository.GetMakeupClasses(query)
+}
+
+func (s *AcademicService) GetRoomChanges(query domain.RoomChangeQuery) ([]domain.RoomChange, error) {
+	return s.repository.GetRoomChanges(query)
 }
 


### PR DESCRIPTION
## 概要

`MakeupClassesV1List`（補講一覧）、`CancelledClassesV1List`（休講一覧）、`RoomChangesV1List`（教室変更一覧）の3つの未実装ハンドラを実装した。

## 変更内容

- **ドメインモデル追加**: `CancelledClass`, `MakeupClass`, `RoomChange` とそれぞれの検索クエリ構造体を新規作成
- **External変換関数追加**: 外部API型⇔ドメイン型の変換関数を各リソースごとに作成
- **Repository拡張**: `AcademicRepository` に3つのList取得メソッドを追加（外部APIクライアント呼び出し）
- **Service拡張**: `AcademicService` のインターフェースと実装に3メソッドを追加
- **Handler実装**: 3つのハンドラを既存パターン（service nil チェック → クエリ変換 → service呼び出し → レスポンス変換）に従って実装

## 確認事項

- [x] `task build` でビルドが通ること
- [x] `task test` で既存テストが全てPASSすること