### PR TITLE
未実装だった /v1/menuItems と /v1/reservations のハンドラを実装

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,10 +55,14 @@ func main() {
 	userRepository := repository.NewUserRepository(clients.User)
 	userService := service.NewUserService(userRepository)
 
+	funchRepository := repository.NewFunchRepository(clients.Funch)
+	funchService := service.NewFunchService(funchRepository)
+
 	h := handler.NewHandler(
 		handler.WithAnnouncementService(announcementService),
 		handler.WithAcademicService(academicService),
 		handler.WithUserService(userService),
+		handler.WithFunchService(funchService),
 	)
 
 	strictHandler := api.NewStrictHandler(h, nil)

--- a/internal/domain/menu_item.go
+++ b/internal/domain/menu_item.go
@@ -1,0 +1,44 @@
+package domain
+
+import "time"
+
+// MenuCategory メニュー分類
+type MenuCategory string
+
+const (
+	MenuCategorySetAndSingle MenuCategory = "SetAndSingle"
+	MenuCategoryBowlAndCurry MenuCategory = "BowlAndCurry"
+	MenuCategoryNoodle       MenuCategory = "Noodle"
+	MenuCategorySide         MenuCategory = "Side"
+	MenuCategoryDessert      MenuCategory = "Dessert"
+)
+
+// MenuSize メニューサイズ
+type MenuSize string
+
+const (
+	MenuSizeSmall  MenuSize = "Small"
+	MenuSizeMedium MenuSize = "Medium"
+	MenuSizeLarge  MenuSize = "Large"
+)
+
+// MenuPrice メニュー価格
+type MenuPrice struct {
+	Size  MenuSize
+	Price int32
+}
+
+// MenuItem メニュー項目
+type MenuItem struct {
+	ID       string
+	Date     time.Time
+	Name     string
+	ImageURL string
+	Category MenuCategory
+	Prices   []MenuPrice
+}
+
+// MenuItemQuery メニュー検索クエリ
+type MenuItemQuery struct {
+	Date time.Time
+}

--- a/internal/domain/reservation.go
+++ b/internal/domain/reservation.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// Reservation 教室の予約
+type Reservation struct {
+	ID      string
+	Room    Room
+	StartAt time.Time
+	EndAt   time.Time
+	Title   string
+}
+
+// ReservationQuery 予約検索クエリ
+type ReservationQuery struct {
+	RoomIDs []string
+	From    *time.Time
+	Until   *time.Time
+}

--- a/internal/external/menu_item_model.go
+++ b/internal/external/menu_item_model.go
@@ -1,0 +1,33 @@
+package external
+
+import (
+	"github.com/fun-dotto/app-bff-api/generated/external/funch_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ToDomainMenuItem は外部APIのMenuItemをDomainに変換する
+func ToDomainMenuItem(m funch_api.MenuItem) domain.MenuItem {
+	prices := make([]domain.MenuPrice, len(m.Prices))
+	for i, p := range m.Prices {
+		prices[i] = domain.MenuPrice{
+			Size:  domain.MenuSize(p.Size),
+			Price: p.Price,
+		}
+	}
+	return domain.MenuItem{
+		ID:       m.Id,
+		Date:     m.Date.Time,
+		Name:     m.Name,
+		ImageURL: m.ImageUrl,
+		Category: domain.MenuCategory(m.Category),
+		Prices:   prices,
+	}
+}
+
+// ToExternalMenuItemQuery はDomainのMenuItemQueryを外部APIのパラメータに変換する
+func ToExternalMenuItemQuery(q domain.MenuItemQuery) *funch_api.MenuItemsV1ListParams {
+	return &funch_api.MenuItemsV1ListParams{
+		Date: openapi_types.Date{Time: q.Date},
+	}
+}

--- a/internal/external/reservation_model.go
+++ b/internal/external/reservation_model.go
@@ -1,0 +1,34 @@
+package external
+
+import (
+	"github.com/fun-dotto/app-bff-api/generated/external/academic_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+)
+
+// ToDomainReservation は外部APIのReservationをDomainに変換する
+func ToDomainReservation(m academic_api.Reservation) domain.Reservation {
+	return domain.Reservation{
+		ID: m.Id,
+		Room: domain.Room{
+			ID:    m.Room.Id,
+			Name:  m.Room.Name,
+			Floor: domain.Floor(m.Room.Floor),
+		},
+		StartAt: m.StartAt,
+		EndAt:   m.EndAt,
+		Title:   m.Title,
+	}
+}
+
+// ToExternalReservationQuery はDomainのReservationQueryを外部APIのパラメータに変換する
+func ToExternalReservationQuery(q domain.ReservationQuery) *academic_api.ReservationsV1ListParams {
+	params := &academic_api.ReservationsV1ListParams{
+		From:  q.From,
+		Until: q.Until,
+	}
+	if len(q.RoomIDs) > 0 {
+		ids := q.RoomIDs
+		params.RoomIds = &ids
+	}
+	return params
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -10,12 +10,14 @@ var (
 	errAnnouncementServiceNotConfigured = errors.New("announcementService is not configured")
 	errAcademicServiceNotConfigured     = errors.New("academicService is not configured")
 	errUserServiceNotConfigured         = errors.New("userService is not configured")
+	errFunchServiceNotConfigured        = errors.New("funchService is not configured")
 )
 
 type Handler struct {
 	announcementService *service.AnnouncementService
 	academicService     *service.AcademicService
 	userService         *service.UserService
+	funchService        *service.FunchService
 }
 
 type Option func(*Handler)
@@ -35,6 +37,12 @@ func WithAcademicService(s *service.AcademicService) Option {
 func WithUserService(s *service.UserService) Option {
 	return func(h *Handler) {
 		h.userService = s
+	}
+}
+
+func WithFunchService(s *service.FunchService) Option {
+	return func(h *Handler) {
+		h.funchService = s
 	}
 }
 

--- a/internal/handler/menu_item.go
+++ b/internal/handler/menu_item.go
@@ -5,8 +5,46 @@ import (
 	"fmt"
 
 	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func (h *Handler) MenuItemsV1List(_ context.Context, _ api.MenuItemsV1ListRequestObject) (api.MenuItemsV1ListResponseObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *Handler) MenuItemsV1List(_ context.Context, request api.MenuItemsV1ListRequestObject) (api.MenuItemsV1ListResponseObject, error) {
+	if h.funchService == nil {
+		return nil, errFunchServiceNotConfigured
+	}
+
+	query := domain.MenuItemQuery{Date: request.Params.Date.Time}
+
+	items, err := h.funchService.GetMenuItems(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get menu items: %w", err)
+	}
+
+	apiItems := make([]api.MenuItem, len(items))
+	for i, item := range items {
+		apiItems[i] = toApiMenuItem(item)
+	}
+
+	return api.MenuItemsV1List200JSONResponse{
+		MenuItems: apiItems,
+	}, nil
+}
+
+func toApiMenuItem(m domain.MenuItem) api.MenuItem {
+	prices := make([]api.Price, len(m.Prices))
+	for i, p := range m.Prices {
+		prices[i] = api.Price{
+			Size:  api.Size(p.Size),
+			Price: p.Price,
+		}
+	}
+	return api.MenuItem{
+		Id:       m.ID,
+		Date:     openapi_types.Date{Time: m.Date},
+		Name:     m.Name,
+		ImageUrl: m.ImageURL,
+		Category: api.Category(m.Category),
+		Prices:   prices,
+	}
 }

--- a/internal/handler/menu_item_test.go
+++ b/internal/handler/menu_item_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/repository"
+	"github.com/fun-dotto/app-bff-api/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMenuItemsV1List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  *Handler
+		validate func(t *testing.T, resp api.MenuItemsV1ListResponseObject, err error)
+	}{
+		{
+			name:    "正常にメニュー一覧が取得できる",
+			handler: NewHandler(WithFunchService(service.NewFunchService(repository.NewMockFunchRepository()))),
+			validate: func(t *testing.T, resp api.MenuItemsV1ListResponseObject, err error) {
+				require.NoError(t, err)
+				result, ok := resp.(api.MenuItemsV1List200JSONResponse)
+				require.True(t, ok, "レスポンスが200 JSONレスポンスではありません")
+				require.Len(t, result.MenuItems, 1)
+				assert.Equal(t, "menu-1", result.MenuItems[0].Id)
+				assert.Equal(t, "からあげ定食", result.MenuItems[0].Name)
+				assert.Equal(t, api.Category("SetAndSingle"), result.MenuItems[0].Category)
+				require.Len(t, result.MenuItems[0].Prices, 1)
+				assert.Equal(t, api.Size("Medium"), result.MenuItems[0].Prices[0].Size)
+				assert.Equal(t, int32(500), result.MenuItems[0].Prices[0].Price)
+			},
+		},
+		{
+			name:    "funchServiceが未設定の場合エラーを返す",
+			handler: NewHandler(),
+			validate: func(t *testing.T, resp api.MenuItemsV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errFunchServiceNotConfigured)
+			},
+		},
+		{
+			name:    "serviceがエラーを返す場合エラーを返す",
+			handler: NewHandler(WithFunchService(service.NewFunchService(repository.NewMockFunchRepositoryWithError("getMenuItems", fmt.Errorf("db error"))))),
+			validate: func(t *testing.T, resp api.MenuItemsV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get menu items")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.handler.MenuItemsV1List(context.Background(), api.MenuItemsV1ListRequestObject{})
+			tt.validate(t, resp, err)
+		})
+	}
+}

--- a/internal/handler/reservation.go
+++ b/internal/handler/reservation.go
@@ -5,8 +5,52 @@ import (
 	"fmt"
 
 	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
 )
 
-func (h *Handler) ReservationsV1List(_ context.Context, _ api.ReservationsV1ListRequestObject) (api.ReservationsV1ListResponseObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *Handler) ReservationsV1List(_ context.Context, request api.ReservationsV1ListRequestObject) (api.ReservationsV1ListResponseObject, error) {
+	if h.academicService == nil {
+		return nil, errAcademicServiceNotConfigured
+	}
+
+	query := toReservationQuery(request.Params)
+
+	reservations, err := h.academicService.GetReservations(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reservations: %w", err)
+	}
+
+	apiReservations := make([]api.Reservation, len(reservations))
+	for i, r := range reservations {
+		apiReservations[i] = toApiReservation(r)
+	}
+
+	return api.ReservationsV1List200JSONResponse{
+		Reservations: apiReservations,
+	}, nil
+}
+
+func toReservationQuery(params api.ReservationsV1ListParams) domain.ReservationQuery {
+	query := domain.ReservationQuery{
+		From:  params.From,
+		Until: params.Until,
+	}
+	if params.RoomIds != nil {
+		query.RoomIDs = *params.RoomIds
+	}
+	return query
+}
+
+func toApiReservation(r domain.Reservation) api.Reservation {
+	return api.Reservation{
+		Id: r.ID,
+		Room: api.Room{
+			Id:    r.Room.ID,
+			Name:  r.Room.Name,
+			Floor: api.DottoFoundationV1Floor(r.Room.Floor),
+		},
+		StartAt: r.StartAt,
+		EndAt:   r.EndAt,
+		Title:   r.Title,
+	}
 }

--- a/internal/handler/reservation_test.go
+++ b/internal/handler/reservation_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/fun-dotto/app-bff-api/generated"
+	"github.com/fun-dotto/app-bff-api/internal/repository"
+	"github.com/fun-dotto/app-bff-api/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservationsV1List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  *Handler
+		validate func(t *testing.T, resp api.ReservationsV1ListResponseObject, err error)
+	}{
+		{
+			name:    "正常に予約一覧が取得できる",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepository()))),
+			validate: func(t *testing.T, resp api.ReservationsV1ListResponseObject, err error) {
+				require.NoError(t, err)
+				result, ok := resp.(api.ReservationsV1List200JSONResponse)
+				require.True(t, ok, "レスポンスが200 JSONレスポンスではありません")
+				require.Len(t, result.Reservations, 1)
+				assert.Equal(t, "reservation-1", result.Reservations[0].Id)
+				assert.Equal(t, "ゼミ", result.Reservations[0].Title)
+				assert.Equal(t, "r1", result.Reservations[0].Room.Id)
+				assert.Equal(t, api.DottoFoundationV1Floor("Floor1"), result.Reservations[0].Room.Floor)
+			},
+		},
+		{
+			name:    "academicServiceが未設定の場合エラーを返す",
+			handler: NewHandler(),
+			validate: func(t *testing.T, resp api.ReservationsV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errAcademicServiceNotConfigured)
+			},
+		},
+		{
+			name:    "serviceがエラーを返す場合エラーを返す",
+			handler: NewHandler(WithAcademicService(service.NewAcademicService(repository.NewMockAcademicRepositoryWithError("getReservations", fmt.Errorf("db error"))))),
+			validate: func(t *testing.T, resp api.ReservationsV1ListResponseObject, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get reservations")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.handler.ReservationsV1List(context.Background(), api.ReservationsV1ListRequestObject{})
+			tt.validate(t, resp, err)
+		})
+	}
+}

--- a/internal/infrastructure/clients.go
+++ b/internal/infrastructure/clients.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fun-dotto/app-bff-api/generated/external/academic_api"
 	"github.com/fun-dotto/app-bff-api/generated/external/announcement_api"
+	"github.com/fun-dotto/app-bff-api/generated/external/funch_api"
 	"github.com/fun-dotto/app-bff-api/generated/external/user_api"
 	"google.golang.org/api/idtoken"
 )
@@ -20,6 +21,7 @@ type ExternalClients struct {
 	Announcement *announcement_api.ClientWithResponses
 	Academic     *academic_api.ClientWithResponses
 	User         *user_api.ClientWithResponses
+	Funch        *funch_api.ClientWithResponses
 }
 
 // NewExternalClients 全ての外部APIクライアントを初期化
@@ -39,10 +41,16 @@ func NewExternalClients(ctx context.Context) (*ExternalClients, error) {
 		return nil, fmt.Errorf("user client: %w", err)
 	}
 
+	funch, err := newFunchClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("funch client: %w", err)
+	}
+
 	return &ExternalClients{
 		Announcement: announcement,
 		Academic:     academic,
 		User:         user,
+		Funch:        funch,
 	}, nil
 }
 
@@ -94,6 +102,23 @@ func newUserClient(ctx context.Context) (*user_api.ClientWithResponses, error) {
 	return user_api.NewClientWithResponses(
 		url,
 		user_api.WithHTTPClient(authClient),
+	)
+}
+
+func newFunchClient(ctx context.Context) (*funch_api.ClientWithResponses, error) {
+	url := os.Getenv("FUNCH_API_URL")
+	if url == "" {
+		return nil, fmt.Errorf("FUNCH_API_URL is required")
+	}
+
+	authClient, err := newAuthHTTPClient(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return funch_api.NewClientWithResponses(
+		url,
+		funch_api.WithHTTPClient(authClient),
 	)
 }
 

--- a/internal/repository/academic.go
+++ b/internal/repository/academic.go
@@ -269,6 +269,28 @@ func (r *AcademicRepository) GetRoomChanges(query domain.RoomChangeQuery) ([]dom
 	return result, nil
 }
 
+// GetReservations は外部APIから予約一覧を取得する
+func (r *AcademicRepository) GetReservations(query domain.ReservationQuery) ([]domain.Reservation, error) {
+	params := external.ToExternalReservationQuery(query)
+
+	response, err := r.client.ReservationsV1ListWithResponse(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call academic API: %w", err)
+	}
+
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get reservations: status %d", response.StatusCode())
+	}
+
+	items := response.JSON200.Reservations
+	result := make([]domain.Reservation, len(items))
+	for i, item := range items {
+		result[i] = external.ToDomainReservation(item)
+	}
+
+	return result, nil
+}
+
 func externalToCourseSemesters(semesters []domain.CourseSemester) []academic_api.DottoFoundationV1CourseSemester {
 	result := make([]academic_api.DottoFoundationV1CourseSemester, len(semesters))
 	for i, semester := range semesters {

--- a/internal/repository/academic_mock.go
+++ b/internal/repository/academic_mock.go
@@ -22,6 +22,7 @@ type MockAcademicRepository struct {
 	getCancelledClassesErr      error
 	getMakeupClassesErr         error
 	getRoomChangesErr           error
+	getReservationsErr          error
 }
 
 func NewMockAcademicRepository() *MockAcademicRepository {
@@ -98,6 +99,8 @@ func NewMockAcademicRepositoryWithError(field string, err error) *MockAcademicRe
 		m.getMakeupClassesErr = err
 	case "getRoomChanges":
 		m.getRoomChangesErr = err
+	case "getReservations":
+		m.getReservationsErr = err
 	}
 	return m
 }
@@ -203,6 +206,25 @@ func (m *MockAcademicRepository) GetMakeupClasses(_ domain.MakeupClassQuery) ([]
 			Date:    time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
 			Period:  domain.PeriodPeriod2,
 			Subject: m.subjects[0],
+		},
+	}, nil
+}
+
+func (m *MockAcademicRepository) GetReservations(_ domain.ReservationQuery) ([]domain.Reservation, error) {
+	if m.getReservationsErr != nil {
+		return nil, m.getReservationsErr
+	}
+	return []domain.Reservation{
+		{
+			ID: "reservation-1",
+			Room: domain.Room{
+				ID:    "r1",
+				Name:  "101講義室",
+				Floor: domain.Floor1,
+			},
+			StartAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+			EndAt:   time.Date(2026, 4, 20, 11, 30, 0, 0, time.UTC),
+			Title:   "ゼミ",
 		},
 	}, nil
 }

--- a/internal/repository/funch.go
+++ b/internal/repository/funch.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fun-dotto/app-bff-api/generated/external/funch_api"
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+	"github.com/fun-dotto/app-bff-api/internal/external"
+)
+
+type FunchRepository struct {
+	client *funch_api.ClientWithResponses
+}
+
+func NewFunchRepository(client *funch_api.ClientWithResponses) *FunchRepository {
+	return &FunchRepository{client: client}
+}
+
+// GetMenuItems は外部APIからメニュー一覧を取得する
+func (r *FunchRepository) GetMenuItems(query domain.MenuItemQuery) ([]domain.MenuItem, error) {
+	params := external.ToExternalMenuItemQuery(query)
+
+	response, err := r.client.MenuItemsV1ListWithResponse(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call funch API: %w", err)
+	}
+
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get menu items: status %d", response.StatusCode())
+	}
+
+	items := response.JSON200.MenuItems
+	result := make([]domain.MenuItem, len(items))
+	for i, item := range items {
+		result[i] = external.ToDomainMenuItem(item)
+	}
+
+	return result, nil
+}

--- a/internal/repository/funch_mock.go
+++ b/internal/repository/funch_mock.go
@@ -1,0 +1,46 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/fun-dotto/app-bff-api/internal/domain"
+)
+
+// MockFunchRepository はテスト用のモック
+type MockFunchRepository struct {
+	menuItems        []domain.MenuItem
+	getMenuItemsErr  error
+}
+
+func NewMockFunchRepository() *MockFunchRepository {
+	return &MockFunchRepository{
+		menuItems: []domain.MenuItem{
+			{
+				ID:       "menu-1",
+				Date:     time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
+				Name:     "からあげ定食",
+				ImageURL: "https://example.com/karaage.png",
+				Category: domain.MenuCategorySetAndSingle,
+				Prices: []domain.MenuPrice{
+					{Size: domain.MenuSizeMedium, Price: 500},
+				},
+			},
+		},
+	}
+}
+
+func NewMockFunchRepositoryWithError(field string, err error) *MockFunchRepository {
+	m := NewMockFunchRepository()
+	switch field {
+	case "getMenuItems":
+		m.getMenuItemsErr = err
+	}
+	return m
+}
+
+func (m *MockFunchRepository) GetMenuItems(_ domain.MenuItemQuery) ([]domain.MenuItem, error) {
+	if m.getMenuItemsErr != nil {
+		return nil, m.getMenuItemsErr
+	}
+	return m.menuItems, nil
+}

--- a/internal/service/academic.go
+++ b/internal/service/academic.go
@@ -19,6 +19,7 @@ type AcademicRepository interface {
 	GetCancelledClasses(query domain.CancelledClassQuery) ([]domain.CancelledClass, error)
 	GetMakeupClasses(query domain.MakeupClassQuery) ([]domain.MakeupClass, error)
 	GetRoomChanges(query domain.RoomChangeQuery) ([]domain.RoomChange, error)
+	GetReservations(query domain.ReservationQuery) ([]domain.Reservation, error)
 }
 
 type AcademicService struct {
@@ -75,5 +76,9 @@ func (s *AcademicService) GetMakeupClasses(query domain.MakeupClassQuery) ([]dom
 
 func (s *AcademicService) GetRoomChanges(query domain.RoomChangeQuery) ([]domain.RoomChange, error) {
 	return s.repository.GetRoomChanges(query)
+}
+
+func (s *AcademicService) GetReservations(query domain.ReservationQuery) ([]domain.Reservation, error) {
+	return s.repository.GetReservations(query)
 }
 

--- a/internal/service/funch.go
+++ b/internal/service/funch.go
@@ -1,0 +1,19 @@
+package service
+
+import "github.com/fun-dotto/app-bff-api/internal/domain"
+
+type FunchRepository interface {
+	GetMenuItems(query domain.MenuItemQuery) ([]domain.MenuItem, error)
+}
+
+type FunchService struct {
+	repository FunchRepository
+}
+
+func NewFunchService(repository FunchRepository) *FunchService {
+	return &FunchService{repository: repository}
+}
+
+func (s *FunchService) GetMenuItems(query domain.MenuItemQuery) ([]domain.MenuItem, error) {
+	return s.repository.GetMenuItems(query)
+}


### PR DESCRIPTION
## 概要

`internal/handler/menu_item.go` と `internal/handler/reservation.go` がこれまで `return nil, fmt.Errorf(\"not implemented\")` を返すスタブのままだったため、OpenAPI スキーマ（`openapi/openapi.yaml`）で定義済みの以下2エンドポイントを実装しました。

- `GET /v1/menuItems` (`MenuItemsV1List`) → Funch Service (`funch_api`) の `/v1/menuItems` に委譲
- `GET /v1/reservations` (`ReservationsV1List`) → Academic Service (`academic_api`) の `/v1/reservations` に委譲

クリーンアーキテクチャ（domain → repository → service → handler）に沿って、既存の `CancelledClasses` / `RoomChanges` / `Announcements` 系と同じパターンに揃えています。

## 変更内容

### 1. 予約一覧取得 (ReservationsV1List)

既存の `AcademicRepository` / `AcademicService` に `GetReservations` を追加し、academic_api の既存クライアントへ委譲。

- 追加: `internal/domain/reservation.go`（`Reservation`, `ReservationQuery`）
- 追加: `internal/external/reservation_model.go`（外部⇔domain 変換）
- 追加: `AcademicRepository.GetReservations` / `AcademicService.GetReservations`
- 追加: `MockAcademicRepository.GetReservations`（`getReservations` エラーフック）
- 実装: `internal/handler/reservation.go`
- 追加: `internal/handler/reservation_test.go`（正常系 / service 未設定 / repository エラー）

### 2. メニュー一覧取得 (MenuItemsV1List)

Funch API は未接続だったため、外部クライアントを新設したうえで repository / service / handler を追加。

- `ExternalClients` に `Funch *funch_api.ClientWithResponses` を追加（環境変数 `FUNCH_API_URL` を参照）
- 追加: `internal/domain/menu_item.go`（`MenuItem`, `MenuCategory`, `MenuSize`, `MenuPrice`, `MenuItemQuery`）
- 追加: `internal/external/menu_item_model.go`
- 追加: `internal/service/funch.go`（`FunchService` + `FunchRepository` interface）
- 追加: `internal/repository/funch.go` / `internal/repository/funch_mock.go`
- 追加: `Handler.funchService` / `WithFunchService` Option / `errFunchServiceNotConfigured`
- 実装: `internal/handler/menu_item.go`
- 追加: `internal/handler/menu_item_test.go`
- 更新: `cmd/server/main.go` で Funch の DI を追加

## 新規環境変数

- `FUNCH_API_URL` — Funch Service のベース URL（他の `*_API_URL` と同じ扱い）

## 動作確認

- `task build` 通過
- `task test` 全件通過（新規追加の `TestMenuItemsV1List` / `TestReservationsV1List` を含む）

実 API との結合確認はデプロイ先環境で `FUNCH_API_URL` を設定のうえ実施してください。